### PR TITLE
Replace GPT-5 with GPT-4o for vision processing

### DIFF
--- a/__tests__/dataConversion.test.js
+++ b/__tests__/dataConversion.test.js
@@ -12,7 +12,7 @@ describe('jsonToCsv', () => {
         file_name: 'test1.jpg',
         processed_date: '2024-03-05',
         ai_provider: 'openai',
-        model_version: 'gpt-5',
+        model_version: 'gpt-4o',
         prompt_version: '1.0'
       },
       {
@@ -31,7 +31,7 @@ describe('jsonToCsv', () => {
 
     const expectedCsv = 
       'memorial_number,first_name,last_name,year_of_death,inscription,file_name,ai_provider,model_version,prompt_version,processed_date\n' +
-      '001,John,Doe,1990,Rest In Peace,test1.jpg,openai,gpt-5,1.0,2024-03-05\n' +
+      '001,John,Doe,1990,Rest In Peace,test1.jpg,openai,gpt-4o,1.0,2024-03-05\n' +
       '002,Jane,Smith,1995,Forever Remembered,test2.jpg,anthropic,claude-4-sonnet-20250514,1.0,2024-03-05\n';
 
     const resultCsv = jsonToCsv(jsonData);
@@ -78,14 +78,14 @@ describe('jsonToCsv', () => {
         file_name: 'test1.jpg',
         processed_date: '2024-03-05',
         ai_provider: 'openai',
-        model_version: 'gpt-5',
+        model_version: 'gpt-4o',
         prompt_version: '1.0'
       }
     ];
 
     const expectedCsv = 
       'memorial_number,first_name,last_name,year_of_death,inscription,file_name,ai_provider,model_version,prompt_version,processed_date\n' +
-      '001,"John, Jr.",Doe,1990,"Rest, In Peace",test1.jpg,openai,gpt-5,1.0,2024-03-05\n';
+      '001,"John, Jr.",Doe,1990,"Rest, In Peace",test1.jpg,openai,gpt-4o,1.0,2024-03-05\n';
 
     const resultCsv = jsonToCsv(jsonData);
     expect(resultCsv).toEqual(expectedCsv);

--- a/__tests__/database/storeMemorial.test.js
+++ b/__tests__/database/storeMemorial.test.js
@@ -101,7 +101,7 @@ describe('storeMemorial Function', () => {
       inscription: 'Test inscription',
       fileName: 'test.jpg',
       ai_provider: 'openai',
-      model_version: 'gpt-5',
+      model_version: 'gpt-4o',
       prompt_template: 'memorialOCR',
       prompt_version: '1.0'
     };
@@ -118,7 +118,7 @@ describe('storeMemorial Function', () => {
         'Test inscription',
         'test.jpg',
         'openai',
-        'gpt-5',
+        'gpt-4o',
         'memorialOCR',
         '1.0',
         expect.any(String)

--- a/__tests__/downloadFunctionality.test.js
+++ b/__tests__/downloadFunctionality.test.js
@@ -28,7 +28,7 @@ describe('Download Functionality', () => {
         inscription: 'Test inscription',
         file_name: 'test.jpg',
         ai_provider: 'openai',
-        model_version: 'gpt-5',
+        model_version: 'gpt-4o',
         prompt_version: '1.0.0',
         processed_date: '2024-03-20T10:00:00.000Z'
       }];
@@ -38,7 +38,7 @@ describe('Download Functionality', () => {
 
       const data = JSON.parse(res._getData());
       expect(data[0]).toHaveProperty('ai_provider', 'openai');
-      expect(data[0]).toHaveProperty('model_version', 'gpt-5');
+      expect(data[0]).toHaveProperty('model_version', 'gpt-4o');
       expect(data[0]).toHaveProperty('prompt_version', '1.0.0');
     });
 
@@ -91,7 +91,7 @@ describe('Download Functionality', () => {
         inscription: 'Test inscription',
         file_name: 'test.jpg',
         ai_provider: 'openai',
-        model_version: 'gpt-5',
+        model_version: 'gpt-4o',
         prompt_version: '1.0.0',
         processed_date: '2024-03-20T10:00:00.000Z'
       }];

--- a/__tests__/performanceTracker.test.js
+++ b/__tests__/performanceTracker.test.js
@@ -28,7 +28,7 @@ describe('PerformanceTracker', () => {
       
       const result = await PerformanceTracker.trackAPICall(
         'openai',
-        'gpt-5',
+        'gpt-4o',
         'processImage',
         mockFn,
         { testMetadata: 'value' }
@@ -38,10 +38,10 @@ describe('PerformanceTracker', () => {
       expect(mockFn).toHaveBeenCalledTimes(1);
 
       const stats = tracker.getStats();
-      expect(stats['openai-gpt-5']).toBeDefined();
-      expect(stats['openai-gpt-5'].totalCalls).toBe(1);
-      expect(stats['openai-gpt-5'].successfulCalls).toBe(1);
-      expect(stats['openai-gpt-5'].failedCalls).toBe(0);
+      expect(stats['openai-gpt-4o']).toBeDefined();
+      expect(stats['openai-gpt-4o'].totalCalls).toBe(1);
+      expect(stats['openai-gpt-4o'].successfulCalls).toBe(1);
+      expect(stats['openai-gpt-4o'].failedCalls).toBe(0);
     });
 
     test('should track failed API calls', async () => {
@@ -73,15 +73,15 @@ describe('PerformanceTracker', () => {
       
       await PerformanceTracker.trackAPICall(
         'openai',
-        'gpt-5',
+        'gpt-4o',
         'processImage',
         mockFn
       );
 
       const stats = tracker.getStats();
-      expect(stats['openai-gpt-5'].averageResponseTime).toBeGreaterThan(90);
-      expect(stats['openai-gpt-5'].minResponseTime).toBeGreaterThan(90);
-      expect(stats['openai-gpt-5'].maxResponseTime).toBeGreaterThan(90);
+      expect(stats['openai-gpt-4o'].averageResponseTime).toBeGreaterThan(90);
+      expect(stats['openai-gpt-4o'].minResponseTime).toBeGreaterThan(90);
+      expect(stats['openai-gpt-4o'].maxResponseTime).toBeGreaterThan(90);
     });
   });
 
@@ -94,12 +94,12 @@ describe('PerformanceTracker', () => {
     test('should filter stats by provider', async () => {
       const mockFn = jest.fn().mockResolvedValue({ success: true });
       
-      await PerformanceTracker.trackAPICall('openai', 'gpt-5', 'processImage', mockFn);
+      await PerformanceTracker.trackAPICall('openai', 'gpt-4o', 'processImage', mockFn);
       await PerformanceTracker.trackAPICall('anthropic', 'claude-4-sonnet-20250514', 'processImage', mockFn);
 
       const openaiStats = tracker.getStats('openai');
       expect(Object.keys(openaiStats)).toHaveLength(1);
-      expect(openaiStats['openai-gpt-5']).toBeDefined();
+      expect(openaiStats['openai-gpt-4o']).toBeDefined();
 
       const anthropicStats = tracker.getStats('anthropic');
       expect(Object.keys(anthropicStats)).toHaveLength(1);
@@ -110,17 +110,17 @@ describe('PerformanceTracker', () => {
       const successFn = jest.fn().mockResolvedValue({ success: true });
       const failFn = jest.fn().mockRejectedValue(new Error('Failed'));
       
-      await PerformanceTracker.trackAPICall('openai', 'gpt-5', 'processImage', successFn);
-      await PerformanceTracker.trackAPICall('openai', 'gpt-5', 'processImage', successFn);
+      await PerformanceTracker.trackAPICall('openai', 'gpt-4o', 'processImage', successFn);
+      await PerformanceTracker.trackAPICall('openai', 'gpt-4o', 'processImage', successFn);
       
       try {
-        await PerformanceTracker.trackAPICall('openai', 'gpt-5', 'processImage', failFn);
+        await PerformanceTracker.trackAPICall('openai', 'gpt-4o', 'processImage', failFn);
       } catch (e) {
         // Expected to fail
       }
 
       const stats = tracker.getStats();
-      expect(stats['openai-gpt-5'].successRate).toBeCloseTo(66.67, 1);
+      expect(stats['openai-gpt-4o'].successRate).toBeCloseTo(66.67, 1);
     });
   });
 
@@ -128,7 +128,7 @@ describe('PerformanceTracker', () => {
     test('should generate comprehensive summary', async () => {
       const mockFn = jest.fn().mockResolvedValue({ success: true });
       
-      await PerformanceTracker.trackAPICall('openai', 'gpt-5', 'processImage', mockFn);
+      await PerformanceTracker.trackAPICall('openai', 'gpt-4o', 'processImage', mockFn);
       await PerformanceTracker.trackAPICall('anthropic', 'claude-4-sonnet-20250514', 'processImage', mockFn);
 
       const summary = tracker.generateSummary();
@@ -142,7 +142,7 @@ describe('PerformanceTracker', () => {
       
       expect(summary.providerComparison.openai).toBeDefined();
       expect(summary.providerComparison.anthropic).toBeDefined();
-      expect(summary.modelComparison['openai-gpt-5']).toBeDefined();
+      expect(summary.modelComparison['openai-gpt-4o']).toBeDefined();
       expect(summary.modelComparison['anthropic-claude-4-sonnet-20250514']).toBeDefined();
     });
   });
@@ -151,7 +151,7 @@ describe('PerformanceTracker', () => {
     test('should return recent metrics', async () => {
       const mockFn = jest.fn().mockResolvedValue({ success: true });
       
-      await PerformanceTracker.trackAPICall('openai', 'gpt-5', 'processImage', mockFn);
+      await PerformanceTracker.trackAPICall('openai', 'gpt-4o', 'processImage', mockFn);
       await PerformanceTracker.trackAPICall('anthropic', 'claude-4-sonnet-20250514', 'processImage', mockFn);
 
       const recentMetrics = tracker.getRecentMetrics(5);
@@ -164,7 +164,7 @@ describe('PerformanceTracker', () => {
       const mockFn = jest.fn().mockResolvedValue({ success: true });
       
       for (let i = 0; i < 10; i++) {
-        await PerformanceTracker.trackAPICall('openai', 'gpt-5', 'processImage', mockFn);
+        await PerformanceTracker.trackAPICall('openai', 'gpt-4o', 'processImage', mockFn);
       }
 
       const recentMetrics = tracker.getRecentMetrics(5);
@@ -176,7 +176,7 @@ describe('PerformanceTracker', () => {
     test('should clear all metrics', async () => {
       const mockFn = jest.fn().mockResolvedValue({ success: true });
       
-      await PerformanceTracker.trackAPICall('openai', 'gpt-5', 'processImage', mockFn);
+      await PerformanceTracker.trackAPICall('openai', 'gpt-4o', 'processImage', mockFn);
       
       let stats = tracker.getStats();
       expect(Object.keys(stats)).toHaveLength(1);

--- a/__tests__/processFile.test.js
+++ b/__tests__/processFile.test.js
@@ -41,11 +41,21 @@ jest.mock('../src/utils/database', () => ({
   storeMemorial: jest.fn().mockResolvedValue(true)
 }));
 
+// Mock image processing utilities to avoid file system dependency
+jest.mock('../src/utils/imageProcessor', () => ({
+  analyzeImageForProvider: jest.fn().mockResolvedValue({ needsOptimization: false }),
+  optimizeImageForProvider: jest.fn().mockResolvedValue('base64imagestring')
+}));
+
+jest.mock('../src/utils/imageProcessing/monumentCropper', () => ({
+  detectAndCrop: jest.fn().mockResolvedValue(null)
+}));
+
 // Mock the model providers
 jest.mock('../src/utils/modelProviders', () => {
   const OpenAIProvider = jest.fn().mockImplementation(() => ({
     processImage: mockOpenAICreateMethod,
-    getModelVersion: () => 'gpt-5'
+    getModelVersion: () => 'gpt-4o'
   }));
 
   const AnthropicProvider = jest.fn().mockImplementation(() => ({
@@ -98,7 +108,7 @@ describe('processFile', () => {
     const result = await processFile('test.jpg', { provider: 'openai' });
     expect(result).toBeDefined();
     expect(result.ai_provider).toBe('openai');
-    expect(result.model_version).toBe('gpt-5');
+    expect(result.model_version).toBe('gpt-4o');
     expect(mockOpenAICreateMethod).toHaveBeenCalled();
     expect(mockAnthropicCreateMethod).not.toHaveBeenCalled();
   });

--- a/__tests__/ui/modelInfoPanel.test.js
+++ b/__tests__/ui/modelInfoPanel.test.js
@@ -26,7 +26,7 @@ describe('Model Info Panel', () => {
   let container;
   const mockData = {
     ai_provider: 'openai',
-    model_version: 'gpt-5',
+    model_version: 'gpt-4o',
     prompt_template: 'memorial_ocr',
     prompt_version: '1.0.0',
     processed_date: '2024-03-20T10:00:00.000Z'
@@ -117,7 +117,7 @@ describe('Model Info Panel', () => {
 
     it('should display model information correctly', () => {
       expect(document.getElementById('infoProvider').textContent).toBe('OpenAI');
-      expect(document.getElementById('infoModelVersion').textContent).toBe('gpt-5');
+      expect(document.getElementById('infoModelVersion').textContent).toBe('gpt-4o');
     });
 
     it('should display prompt information correctly', () => {

--- a/__tests__/ui/resultsTable.test.js
+++ b/__tests__/ui/resultsTable.test.js
@@ -198,7 +198,7 @@ describe('Results Table UI', () => {
       ai_provider: 'openai',
       prompt_template: 'memorial_ocr',
       prompt_version: '1.0.0',
-      model_version: 'gpt-5',
+      model_version: 'gpt-4o',
       processed_date: '2024-03-20T10:00:00.000Z'
     }];
 

--- a/__tests__/unit/monument-template-selection.test.js
+++ b/__tests__/unit/monument-template-selection.test.js
@@ -30,6 +30,16 @@ jest.mock('../../src/utils/errorTypes', () => ({
   isEmptySheetError: jest.fn().mockReturnValue(false)
 }));
 
+// Mock image processing utilities to avoid file system dependency
+jest.mock('../../src/utils/imageProcessor', () => ({
+  analyzeImageForProvider: jest.fn().mockResolvedValue({ needsOptimization: false }),
+  optimizeImageForProvider: jest.fn().mockResolvedValue('base64imagedata')
+}));
+
+jest.mock('../../src/utils/imageProcessing/monumentCropper', () => ({
+  detectAndCrop: jest.fn().mockResolvedValue(null)
+}));
+
 describe('Monument Template Selection', () => {
   let processFile;
   let createProvider;

--- a/__tests__/utils/dataConversion.test.js
+++ b/__tests__/utils/dataConversion.test.js
@@ -15,7 +15,7 @@ describe('Data Conversion Utils', () => {
       file_name: 'test1.jpg',
       processed_date: '2025-01-01T12:00:00Z',
       ai_provider: 'openai',
-      model_version: 'gpt-5',
+      model_version: 'gpt-4o',
       prompt_version: '1.0'
     },
     {
@@ -47,7 +47,7 @@ describe('Data Conversion Utils', () => {
       expect(lines[0]).toBe('memorial_number,first_name,last_name,year_of_death,inscription,file_name,ai_provider,model_version,prompt_version,processed_date');
       
       // Check first data row
-      expect(lines[1]).toBe('MEM001,John,Doe,1900,Rest in Peace,test1.jpg,openai,gpt-5,1.0,2025-01-01T12:00:00Z');
+      expect(lines[1]).toBe('MEM001,John,Doe,1900,Rest in Peace,test1.jpg,openai,gpt-4o,1.0,2025-01-01T12:00:00Z');
     });
 
     it('should properly handle newlines in fields', () => {

--- a/src/utils/modelProviders/__tests__/openaiProvider.test.js
+++ b/src/utils/modelProviders/__tests__/openaiProvider.test.js
@@ -20,7 +20,7 @@ describe('OpenAIProvider', () => {
   beforeEach(() => {
     mockConfig = {
       OPENAI_API_KEY: 'test-key',
-      OPENAI_MODEL: 'gpt-5',
+      OPENAI_MODEL: 'gpt-4o',
       MAX_TOKENS: 4000,
       TEMPERATURE: 0.2
     };
@@ -61,12 +61,12 @@ describe('OpenAIProvider', () => {
     });
 
     it('should use provided model from config', () => {
-      expect(provider.model).toBe('gpt-5');
+      expect(provider.model).toBe('gpt-4o');
     });
 
     it('should use default model if not specified', () => {
       const defaultProvider = new OpenAIProvider({});
-      expect(defaultProvider.model).toBe('gpt-5');
+      expect(defaultProvider.model).toBe('gpt-4o');
     });
 
     it('should use provided max tokens from config', () => {
@@ -90,7 +90,7 @@ describe('OpenAIProvider', () => {
 
   describe('getModelVersion', () => {
     it('should return current model version', () => {
-      expect(provider.getModelVersion()).toBe('gpt-5');
+      expect(provider.getModelVersion()).toBe('gpt-4o');
     });
   });
 
@@ -102,7 +102,7 @@ describe('OpenAIProvider', () => {
       await provider.processImage(testImage, testPrompt);
       
       expect(provider.client.chat.completions.create).toHaveBeenCalledWith({
-        model: 'gpt-5',
+        model: 'gpt-4o',
         messages: [
           {
             role: 'system',
@@ -122,8 +122,8 @@ describe('OpenAIProvider', () => {
           },
         ],
         response_format: { type: 'json_object' },
-        max_completion_tokens: 4000
-        // Note: temperature is not included for GPT-5 as it only supports default (1)
+        max_completion_tokens: 4000,
+        temperature: 0.2
       });
     });
 

--- a/src/utils/modelProviders/openaiProvider.js
+++ b/src/utils/modelProviders/openaiProvider.js
@@ -15,7 +15,7 @@ class OpenAIProvider extends BaseVisionProvider {
     this.client = new OpenAI({
       apiKey: this.config.OPENAI_API_KEY || process.env.OPENAI_API_KEY
     });
-    this.model = this.config.OPENAI_MODEL || this.config.openAI?.model || 'gpt-5';
+    this.model = this.config.OPENAI_MODEL || this.config.openAI?.model || 'gpt-4o';
     this.maxTokens = this.config.MAX_TOKENS || this.config.openAI?.maxTokens || 4000;
     this.temperature = this.config.TEMPERATURE || 0;
   }
@@ -78,10 +78,8 @@ class OpenAIProvider extends BaseVisionProvider {
         max_completion_tokens: this.maxTokens
       };
 
-      // GPT-5 only supports default temperature (1), so don't include it
-      if (!this.model.includes('gpt-5')) {
-        requestPayload.temperature = this.temperature;
-      }
+      // Include temperature for models that support it
+      requestPayload.temperature = this.temperature;
 
         // Calculate timeout with exponential backoff
         const timeout = baseTimeout * attempt;
@@ -166,7 +164,7 @@ class OpenAIProvider extends BaseVisionProvider {
     if (!this.client) {
       throw new Error('OpenAI client not initialized. Check API key configuration.');
     }
-    if (!this.model.includes('vision') && !this.model.includes('gpt-5') && !this.model.includes('gpt-4o')) {
+    if (!this.model.includes('vision') && !this.model.includes('gpt-4o')) {
       throw new Error('Invalid model specified. Must be a vision-capable model.');
     }
     return true;

--- a/src/utils/performanceTracker.js
+++ b/src/utils/performanceTracker.js
@@ -29,7 +29,7 @@ class PerformanceTracker {
   /**
    * Track an API call with timing and memory usage
    * @param {string} provider - The AI provider (openai, anthropic)
-   * @param {string} model - The model name (gpt-5, claude-4-sonnet-20250514)
+   * @param {string} model - The model name (gpt-4o, claude-4-sonnet-20250514)
    * @param {string} operation - The operation type (processImage, etc)
    * @param {Function} fn - The async function to execute and track
    * @param {Object} metadata - Additional metadata to track


### PR DESCRIPTION
## Summary
- default OpenAI vision model switched from GPT-5 to GPT-4o
- update backend validation and temperature handling for GPT-4o
- align frontend components and tests with GPT-4o model identifier

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c04a19fba083218fb97aa2577112a0