### PR TITLE
chore(security): pin tar-fs to patched versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10797,9 +10797,9 @@
       }
     },
     "node_modules/sharp/node_modules/tar-fs": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
-      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",
@@ -11484,9 +11484,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
-      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "jest --config jest.config.cjs",
-    "start": "SAVE_DEBUG_IMAGES=false node server.js",
-    "dev": "SAVE_DEBUG_IMAGES=false nodemon server.js",
-    "local-start": "SAVE_DEBUG_IMAGES=false NODE_ENV=development nodemon server.js --ignore 'data/*' --ignore 'uploads/*'",
+    "start": "node server.js",
+    "dev": "nodemon server.js",
+    "local-start": "NODE_ENV=development nodemon server.js --ignore 'data/*' --ignore 'uploads/*'",
     "lint": "eslint .",
     "migrate:remove-confidence-score": "node scripts/remove-confidence-score.js",
     "migrate:add-model-columns": "node scripts/migrate-add-model-columns.js",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "jest --config jest.config.cjs",
-    "start": "node server.js",
-    "dev": "nodemon server.js",
-    "local-start": "NODE_ENV=development nodemon server.js --ignore 'data/*' --ignore 'uploads/*'",
+    "start": "SAVE_DEBUG_IMAGES=false node server.js",
+    "dev": "SAVE_DEBUG_IMAGES=false nodemon server.js",
+    "local-start": "SAVE_DEBUG_IMAGES=false NODE_ENV=development nodemon server.js --ignore 'data/*' --ignore 'uploads/*'",
     "lint": "eslint .",
     "migrate:remove-confidence-score": "node scripts/remove-confidence-score.js",
     "migrate:add-model-columns": "node scripts/migrate-add-model-columns.js",
@@ -74,5 +74,13 @@
       "eslint --fix",
       "git add"
     ]
+  },
+  "overrides": {
+    "prebuild-install": {
+      "tar-fs": "2.1.4"
+    },
+    "sharp": {
+      "tar-fs": "3.1.1"
+    }
   }
 }


### PR DESCRIPTION
Mitigates symlink validation bypass in tar-fs by pinning:\n- sharp -> tar-fs@3.1.1 (patched)\n- prebuild-install -> tar-fs@2.1.4 (patched)\n\nAll tests pass locally.\n\nRefs #25